### PR TITLE
Fix use of deprecated ChatCompletion API

### DIFF
--- a/lead_generation_agent.py
+++ b/lead_generation_agent.py
@@ -87,7 +87,7 @@ def generate_query(job: Target) -> str:
         {"role": "user", "content": f"Target name: {job.name}. Criteria: {job.criteria}"},
     ]
 
-    resp = openai.ChatCompletion.create(
+    resp = openai.chat.completions.create(
         model="gpt-3.5-turbo-0613",
         messages=messages,
         temperature=0.2,


### PR DESCRIPTION
## Summary
- fix `openai.ChatCompletion` usage

## Testing
- `python -m py_compile lead_generation_agent.py`
