### PR TITLE
Fix import path for OpenAI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,17 @@ The agent expects the following environment variables:
 - `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` for database access.
 - `OPENAI_API_KEY` for generating search queries and performing web searches.
 
-When the `openai.agents` package is available, `run_agent()` will construct
-an `Agent` with a set of tools to fetch jobs, generate queries, search the web
-and store leads. If the Agents SDK is not installed, it falls back to the
+When the `openai_agents` package is installed and imported, `run_agent()` will
+construct an `Agent` with a set of tools to fetch jobs, generate queries,
+search the web and store leads. If the Agents SDK is not installed, it falls
+back to the
 original manual workflow.
+
+You can verify the package is available with:
+
+```bash
+python -c "import openai_agents, supabase, requests; print('OK')"
+```
 
 ## Compatibility
 

--- a/lead_generation_agent.py
+++ b/lead_generation_agent.py
@@ -28,10 +28,12 @@ except Exception:
 
 
 try:
-    # The Agents SDK ships in newer versions of the openai package. Importing it
-    # conditionally keeps this module compatible with older releases that lack
-    # the `openai.agents` submodule.
-    from openai.agents import Agent, Tool
+    # The openai-agents package exposes its functionality via the
+    # ``openai_agents`` module rather than ``openai.agents``. Importing the
+    # top-level module registers the Agent/Tool API and makes the classes
+    # available for import.
+    import openai_agents  # noqa: F401
+    from openai_agents import Agent, Tool
 except Exception:  # pragma: no cover - optional dependency
     Agent = None  # type: ignore
     Tool = None   # type: ignore


### PR DESCRIPTION
## Summary
- load openai-agents from the `openai_agents` module
- document how to verify the module install

## Testing
- `python -m py_compile lead_generation_agent.py openai_compat.py test_env.py`
- `python - <<'EOF'
import openai_agents
print('openai_agents is here:', dir(openai_agents))
EOF` *(fails: ModuleNotFoundError)*
- `python -c "import openai_agents, supabase, requests; print('OK')"` *(fails: ModuleNotFoundError)*