### PR TITLE
Add created_at field to Target dataclass

### DIFF
--- a/lead_generation_agent.py
+++ b/lead_generation_agent.py
@@ -66,6 +66,7 @@ class Target:
     name: str
     criteria: str
     processed: bool
+    created_at: str
 
 @dataclass
 class Lead:


### PR DESCRIPTION
## Summary
- include `created_at` in the `Target` dataclass so rows returned from Supabase map cleanly

## Testing
- `python -m py_compile lead_generation_agent.py`