### PR TITLE
Use built‑in OpenAI web search

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ The agent expects the following environment variables:
 - `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` for database access.
 - `OPENAI_API_KEY` for generating search queries and performing web searches.
 
+### .env
+SUPABASE_URL=...
+SUPABASE_SERVICE_ROLE_KEY=...
+OPENAI_API_KEY=...
+
+No SerpAPI key needed.
+
 When the `openai_agents` package is installed and imported, `run_agent()` will
 construct an `Agent` with a set of tools to fetch jobs, generate queries,
 search the web, optionally fetch raw HTML pages using a custom `browse_page`

--- a/agent.py
+++ b/agent.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
 
-"""Compatibility wrapper for :mod:`lead_generation_agent`.
+"""Small wrapper to invoke :mod:`agent_driver`.
 
-This module previously contained a standalone implementation that returned
-dummy data via a ``web_search_stub`` function. It now simply delegates to the
-real agent in :mod:`lead_generation_agent`, which performs actual web searches
-and writes results to Supabase when proper credentials are configured.
-
-
+Historically this file implemented a manual workflow with a ``web_search_stub``
+helper. That logic has been removed in favour of the real Agent defined in
+``agent_driver.py``. The file is kept only for backward compatibility so that
+``python agent.py`` still works.
 """
 
-from lead_generation_agent import run_agent
+from agent_driver import agent
 
 
 if __name__ == "__main__":  # pragma: no cover - manual entry point
-    run_agent()
+    result = agent.run("start")
+    print(result.logs)
+

--- a/agent_driver.py
+++ b/agent_driver.py
@@ -1,0 +1,30 @@
+import os, json, openai, openai_agents
+from tools import fetch_targets, insert_lead, mark_processed, web_search
+
+openai.api_key = os.environ["OPENAI_API_KEY"]
+
+SYSTEM = """
+You are a lead-generation agent.
+
+For each target from fetch_targets():
+1. Read target.criteria (a JSON blob).
+2. Produce ONE concise Google query that will find companies or people
+   matching those criteria.
+3. Call browser.search(query) to get live results.
+4. For each result item (title, link, snippet), call insert_lead().
+5. Call mark_processed(target_id) when done.
+
+Return nothing else.
+"""
+
+agent = openai_agents.Agent.from_openai(
+    name="lead-gen-agent",
+    model="gpt-4o",
+    tools=[fetch_targets, web_search, insert_lead, mark_processed],
+    system_message=SYSTEM,
+)
+
+if __name__ == "__main__":
+    result = agent.run("start")
+    print(result.logs)      # full tool-call trace
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
+openai-agents==0.0.15
+openai>=1.77
 python-dotenv
 supabase
-openai>=1.0.0
-openai-agents
 requests

--- a/tools.py
+++ b/tools.py
@@ -1,0 +1,57 @@
+import os, json
+from dotenv import load_dotenv
+from supabase import create_client
+from openai_agents import Tool
+import openai.tools as oat   # built-in browsing tools
+
+load_dotenv()                             # read .env once
+
+# --- Supabase client -------------------------------------------------
+client = create_client(
+    os.environ["SUPABASE_URL"],
+    os.environ["SUPABASE_SERVICE_ROLE_KEY"],
+)
+
+# --- tool: fetch_targets --------------------------------------------
+def _fetch_targets():
+    """Return every targets row where processed == false."""
+    return (client.table("targets")
+                   .select("*")
+                   .eq("processed", False)
+                   .execute()
+                   .data)
+
+fetch_targets = Tool(
+    name="fetch_targets",
+    description="Get all unprocessed targets from Supabase",
+    function=_fetch_targets,
+)
+
+# --- tool: insert_lead ----------------------------------------------
+def _insert_lead(target_id: int, lead: dict):
+    out = (client.table("leads")
+                 .insert({"target_id": target_id, "lead_data": lead})
+                 .execute()
+                 .data)
+    return out[0]["id"]
+
+insert_lead = Tool(
+    name="insert_lead",
+    description="Store one lead row",
+    function=_insert_lead,
+)
+
+# --- tool: mark_processed -------------------------------------------
+def _mark_processed(target_id: int):
+    client.table("targets").update({"processed": True}).eq("id", target_id).execute()
+    return True
+
+mark_processed = Tool(
+    name="mark_processed",
+    description="Flag a target as processed so it is not re-queued",
+    function=_mark_processed,
+)
+
+# --- built-in OpenAI browsing tool ----------------------------------
+# exposes `browser.search` automatically
+web_search = oat.web_search         # ← comes from the SDK docs


### PR DESCRIPTION
## Summary
- pin `openai-agents==0.0.15` and `openai>=1.77`
- add tools for Supabase operations and built-in web search
- create `agent_driver.py` with new Agent configuration
- update `agent.py` wrapper to call the new driver
- document required env vars in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python agent_driver.py` *(fails: ModuleNotFoundError: No module named 'openai_agents')*