### PR TITLE
Fix pip build failures by installing wheels only

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ OPENAI_API_KEY=...
 
 No SerpAPI key needed.
 
+Run the provided `setup.sh` script to install dependencies. It installs
+pre-built wheels only (via `--only-binary`) to avoid expensive source builds.
+
 When the `openai_agents` package is installed and imported, `run_agent()` will
 construct an `Agent` with a set of tools to fetch jobs, generate queries,
 search the web, optionally fetch raw HTML pages using a custom `browse_page`

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 # setup.sh — install all Python dependencies
-pip install --upgrade pip
-pip install -r requirements.txt
+
+# Upgrade core build tooling first
+pip install --upgrade pip wheel setuptools
+
+# Install packages strictly from pre-built wheels to avoid source builds
+pip install --only-binary=:all: -r requirements.txt


### PR DESCRIPTION
## Summary
- document wheel-only install in README
- update `setup.sh` to install wheels exclusively and upgrade build tools

## Testing
- `bash setup.sh` *(fails: Cannot connect to proxy)*