### PR TITLE
Fix import path for Agents SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ OPENAI_API_KEY=...
 
 No SerpAPI key needed.
 
-When the `openai_agents` package is installed and imported, `run_agent()` will
+When the `openai-agents` package is installed it exposes its functionality
+through the `agents` module. When imported, `run_agent()` will
 construct an `Agent` with a set of tools to fetch jobs, generate queries,
 search the web, optionally fetch raw HTML pages using a custom `browse_page`
 tool and store leads. If the Agents SDK is not installed, it falls
@@ -32,12 +33,12 @@ original manual workflow.
 You can verify the package is available with:
 
 ```bash
-python -c "import openai_agents, supabase, requests; print('OK')"
+python -c "import agents, supabase, requests; print('OK')"
 ```
 
 ## Using the virtual environment
 
-If you receive `ModuleNotFoundError: openai_agents`, ensure that the
+If you receive `ModuleNotFoundError: agents`, ensure that the
 interpreter you are invoking is the one from your virtual environment.
 Check with:
 
@@ -57,8 +58,8 @@ or call the venv's interpreter explicitly:
 
 ```bash
 ./venv/bin/python - <<'EOF'
-import openai_agents
-print("Loaded:", openai_agents)
+import agents
+print("Loaded:", agents)
 EOF
 ```
 

--- a/agent_driver.py
+++ b/agent_driver.py
@@ -1,4 +1,5 @@
-import os, json, openai, openai_agents
+import os, json, openai
+import agents as openai_agents
 from tools import fetch_targets, insert_lead, mark_processed, web_search
 
 openai.api_key = os.environ["OPENAI_API_KEY"]

--- a/lead_generation_agent.py
+++ b/lead_generation_agent.py
@@ -32,12 +32,12 @@ except Exception:
 
 
 try:
-    # The openai-agents package exposes its functionality via the
-    # ``openai_agents`` module rather than ``openai.agents``. Importing the
-    # top-level module registers the Agent/Tool API and makes the classes
+    # The OpenAI Agents SDK exposes its functionality via the ``agents``
+    # package (older versions documented it as ``openai_agents``). Importing
+    # the top-level module registers the Agent/Tool API and makes the classes
     # available for import.
-    import openai_agents  # noqa: F401
-    from openai_agents import Agent, Tool
+    import agents  # noqa: F401
+    from agents import Agent, Tool
 except Exception:  # pragma: no cover - optional dependency
     Agent = None  # type: ignore
     Tool = None   # type: ignore

--- a/tools.py
+++ b/tools.py
@@ -1,7 +1,7 @@
 import os, json
 from dotenv import load_dotenv
 from supabase import create_client
-from openai_agents import Tool
+from agents import Tool
 import openai.tools as oat   # built-in browsing tools
 
 load_dotenv()                             # read .env once


### PR DESCRIPTION
## Summary
- import `agents` instead of `openai_agents`
- update agent driver and helper modules
- document the new import path in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`