### PR TITLE
Fix tools schema issues

### DIFF
--- a/tools.py
+++ b/tools.py
@@ -1,4 +1,5 @@
 import os, json
+from typing import Any
 from dotenv import load_dotenv
 from supabase import create_client
 from agents import function_tool, WebSearchTool
@@ -12,7 +13,7 @@ client = create_client(
 
 # --- tool: fetch_targets --------------------------------------------
 @function_tool
-def fetch_targets() -> list[dict]:
+def fetch_targets() -> list[Any]:
     """Return every un-processed row in the targets table."""
     return (
         client.table("targets")
@@ -24,7 +25,7 @@ def fetch_targets() -> list[dict]:
 
 # --- tool: insert_lead ----------------------------------------------
 @function_tool
-def insert_lead(target_id: int, lead: dict) -> int:
+def insert_lead(target_id: int, lead: Any) -> int:
     out = (
         client.table("leads")
               .insert({"target_id": target_id, "lead_data": lead})
@@ -50,5 +51,5 @@ TOOLS = [
     web_search,
 ]
 
-__all__ = ["fetch_targets", "insert_lead", "mark_processed", "web_search", "TOOLS"]
+__all__ = ["TOOLS"]
 


### PR DESCRIPTION
## Summary
- adjust tool type hints for OpenAI Agents
- export only TOOLS from tools module

## Testing
- `python -m py_compile agent_driver.py tools.py openai_compat.py agent.py lead_generation_agent.py`
- `env SUPABASE_URL='http://example.com' SUPABASE_SERVICE_ROLE_KEY='key' OPENAI_API_KEY='sk-test' python agent_driver.py` *(fails: Invalid API key)*